### PR TITLE
Added L2 Regularization to Metalog OLS Fit Method

### DIFF
--- a/PyMetalog_usagetest.py
+++ b/PyMetalog_usagetest.py
@@ -6,7 +6,7 @@ import pymetalog as pm
 fish_data = np.loadtxt('fishout.csv', delimiter=',', skiprows=1, dtype='str')[:,1].astype(np.float)
 
 # metalog creation
-fish_metalog = pm.metalog(x=fish_data, bounds=[0,40], boundedness='b', term_limit=9, term_lower_bound=2, step_len=.001,)
+fish_metalog = pm.metalog(x=fish_data, bounds=[0,40], boundedness='b', term_limit=15, term_lower_bound=2, step_len=.001, regularization=0.)
 
 # summary function
 pm.summary(fish_metalog)

--- a/PyMetalog_usagetest.py
+++ b/PyMetalog_usagetest.py
@@ -6,7 +6,7 @@ import pymetalog as pm
 fish_data = np.loadtxt('fishout.csv', delimiter=',', skiprows=1, dtype='str')[:,1].astype(np.float)
 
 # metalog creation
-fish_metalog = pm.metalog(x=fish_data, bounds=[0,40], boundedness='b', term_limit=15, term_lower_bound=2, step_len=.001, regularization=0.)
+fish_metalog = pm.metalog(x=fish_data, bounds=[0,40], boundedness='b', term_limit=15, term_lower_bound=2, step_len=.001, penalty=None)
 
 # summary function
 pm.summary(fish_metalog)

--- a/pymetalog/a_vector.py
+++ b/pymetalog/a_vector.py
@@ -14,6 +14,7 @@ def a_vector_OLS_and_LP(m_dict,
            term_limit,
            term_lower_bound,
            fit_method,
+           regularization,
            diff_error = .001,
            diff_step = 0.001):
 
@@ -86,6 +87,10 @@ def a_vector_OLS_and_LP(m_dict,
             - 'OLS' only tries to fit by solving directly for a coefficients using ordinary least squares method
             - 'LP' only tries to estimate fit using simplex linear program optimization routine
             - 'MLE' first tries 'OLS' method than falls back to a maximum likelihood estimation routine
+		
+		regularization (:obj:`float`): L2 regularization term to add to OLS fit
+            - strictly >= 0.
+            - Default: 0. (no regularization, OLS)
 
         diff_error (:obj:`float`, optional): Value used to in scipy.optimize.linprog method call
                                              to init the array of values representing the
@@ -120,6 +125,7 @@ def a_vector_OLS_and_LP(m_dict,
     # TODO: Large for-loop can probably be factored into smaller functions
     for i in range(term_lower_bound,term_limit+1):
         Y = m_dict['Y'].iloc[:,0:i]
+        eye = np.eye(Y.shape[1])
         z = m_dict['dataValues']['z']
         y = m_dict['dataValues']['probs']
         step_len = m_dict['params']['step_len']
@@ -132,13 +138,13 @@ def a_vector_OLS_and_LP(m_dict,
 
         if fit_method == 'any' or fit_method == 'MLE':
             try:
-                temp = np.dot(np.dot(np.linalg.inv(np.dot(Y.T, Y)), Y.T), z)
+                temp = np.dot(np.dot(np.linalg.inv(np.dot(Y.T, Y) + regularization*eye), Y.T), z)
             except:
                 temp = a_vector_LP(m_dict, term_limit=i, term_lower_bound=i, diff_error=diff_error, diff_step=diff_step)
                 # use LP solver if OLS breaks
         if fit_method == 'OLS':
             try:
-                temp = np.dot(np.dot(np.linalg.inv(np.dot(Y.T, Y)), Y.T), z)
+                temp = np.dot(np.dot(np.linalg.inv(np.dot(Y.T, Y) + regularization*eye), Y.T), z)
             except:
                 raise RuntimeError("OLS was unable to solve infeasible or poorly formulated problem")
         if fit_method == "LP":

--- a/pymetalog/a_vector.py
+++ b/pymetalog/a_vector.py
@@ -14,7 +14,7 @@ def a_vector_OLS_and_LP(m_dict,
            term_limit,
            term_lower_bound,
            fit_method,
-           regularization,
+           alpha,
            diff_error = .001,
            diff_step = 0.001):
 
@@ -87,9 +87,10 @@ def a_vector_OLS_and_LP(m_dict,
             - 'OLS' only tries to fit by solving directly for a coefficients using ordinary least squares method
             - 'LP' only tries to estimate fit using simplex linear program optimization routine
             - 'MLE' first tries 'OLS' method than falls back to a maximum likelihood estimation routine
-		
-		regularization (:obj:`float`): L2 regularization term to add to OLS fit
+
+        alpha (:obj:`float`, optional): Regularization term to add to OLS fit
             - strictly >= 0.
+            - should be set in conjunction with `penalty` parameter
             - Default: 0. (no regularization, OLS)
 
         diff_error (:obj:`float`, optional): Value used to in scipy.optimize.linprog method call
@@ -138,13 +139,13 @@ def a_vector_OLS_and_LP(m_dict,
 
         if fit_method == 'any' or fit_method == 'MLE':
             try:
-                temp = np.dot(np.dot(np.linalg.inv(np.dot(Y.T, Y) + regularization*eye), Y.T), z)
+                temp = np.dot(np.dot(np.linalg.inv(np.dot(Y.T, Y) + alpha*eye), Y.T), z)
             except:
                 temp = a_vector_LP(m_dict, term_limit=i, term_lower_bound=i, diff_error=diff_error, diff_step=diff_step)
                 # use LP solver if OLS breaks
         if fit_method == 'OLS':
             try:
-                temp = np.dot(np.dot(np.linalg.inv(np.dot(Y.T, Y) + regularization*eye), Y.T), z)
+                temp = np.dot(np.dot(np.linalg.inv(np.dot(Y.T, Y) + alpha*eye), Y.T), z)
             except:
                 raise RuntimeError("OLS was unable to solve infeasible or poorly formulated problem")
         if fit_method == "LP":

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -5,7 +5,7 @@ from .a_vector import a_vector_OLS_and_LP
 
 
 class metalog():
-    def __init__(self, x, bounds=[0,1], boundedness='u', term_limit=13, term_lower_bound=2, step_len=.01, probs=None, fit_method='any'):
+    def __init__(self, x, bounds=[0,1], boundedness='u', term_limit=13, term_lower_bound=2, step_len=.01, probs=None, fit_method='any', regularization=0.):
         """Fits a metalog distribution using the input array `x`.
 
         Args:
@@ -51,6 +51,10 @@ class metalog():
                 - 'LP' only tries to estimate fit using simplex linear program optimization routine
                 - 'MLE' first tries 'OLS' method than falls back to a maximum likelihood estimation routine
 
+            regularization (:obj:`float`, optional): L2 regularization term to add to OLS fit
+                - strictly >= 0.
+                - Default: 0. (no regularization, OLS)
+
         Raises:
             TypeError: 'Input x must be an array or pandas Series'
             TypeError: 'Input x must be an array of allowable types: int, float, numpy.int64, or numpy.float64'
@@ -78,6 +82,7 @@ class metalog():
             ValueError: 'Input probabilities cannot contain nans'
             ValueError: 'Input probabilities must have values between, not including, 0 and 1'
             ValueError: 'fit_method can only be values OLS, LP, any, or MLE'
+            ValueError: 'regularization must only be a float >= 0.'
 
         Example:
 
@@ -105,6 +110,7 @@ class metalog():
         self.step_len = step_len
         self.probs = probs
         self.fit_method = fit_method
+        self.regularization = regularization
 
         if probs == None:
             df_x = MLprobs(self.x, step_len=step_len)
@@ -152,6 +158,7 @@ class metalog():
             term_limit = self.term_limit,
             term_lower_bound = self.term_lower_bound,
             fit_method = self.fit_method,
+            regularization = self.regularization,
             diff_error = .001,
             diff_step = 0.001)
 
@@ -294,6 +301,18 @@ class metalog():
         if fm != 'OLS' and fm != 'LP' and fm != 'any' and fm != 'MLE':
             raise ValueError('fit_method can only be values OLS, LP, any, or MLE')
         self._fit_method = fm
+
+    @property
+    def regularization(self):
+        """regularization (:obj:`float`): L2 regularization term to add to OLS fit"""
+
+        return self._regularization
+
+    @regularization.setter
+    def regularization(self, reg):
+        if reg < 0 or not isinstance(reg,float):
+            raise ValueError('regularization must only be a float >= 0.')
+        self._regularization = reg
 
     def get_params(self):
         """Sets the `params` key (dict) of `output_dict` object prior to input to `a_vector_OLS_and_LP` method.


### PR DESCRIPTION
Hey y'all! I added a new feature based on a conversation I had with Sam last week. See below for commit message.

Added an L2 Regularization term to the Metalog linear regression fit method, essentially turning the Metalog linear regression fit method into a Ridge Regression. This feature prevents overfitting and allows for the user to pick the highest term limit when using the returned metalog object with no degradation to performance.

Before Regularization:

![BeforeRegularization](https://user-images.githubusercontent.com/24706343/69008883-2355a500-0915-11ea-8d85-22a7d5220391.png)

After Regularization:

![AfterRegularization](https://user-images.githubusercontent.com/24706343/69008863-e7224480-0914-11ea-95d1-7efb2c5073ef.png)

If everything checks out I'll rebuild the package and republish it to pypi. Hope y'all are doing alright! Maybe we can jump on a call again soon and catch up?