### PR TITLE
Bayesian Updating v0

### DIFF
--- a/PyMetalog_usagetest.py
+++ b/PyMetalog_usagetest.py
@@ -3,19 +3,20 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import pymetalog as pm
 
+
 fish_data = np.loadtxt('fishout.csv', delimiter=',', skiprows=1, dtype='str')[:,1].astype(np.float)
 
 # metalog creation
-fish_metalog = pm.metalog(x=fish_data, bounds=[0,40], boundedness='b', term_limit=15, term_lower_bound=2, step_len=.001, penalty=None)
+fish_metalog = pm.metalog(x=fish_data, bounds=[0,40], boundedness='b', term_limit=15, term_lower_bound=2, step_len=.001, penalty=None, save_data=True)
 
 # summary function
 pm.summary(fish_metalog)
 
-# plot function - right now this saves plots to local
+# # plot function - right now this saves plots to local
 pm.plot(fish_metalog)
 plt.show()
 
-# metalog random sampling
+# # metalog random sampling
 r_gens = pm.rmetalog(fish_metalog, n = 1000, term = 9, generator='hdr')
 plt.hist(r_gens,14)
 plt.show()
@@ -31,3 +32,26 @@ print("pmetalog demo: "+str(ps))
 # density from a quantile
 ds = pm.dmetalog(fish_metalog, q = [3, 10, 25], term = 9)
 print("dmetalog demo: "+str(ds))
+
+# Bayesian metalog updating
+# Will split dataset and fit to one part and update using other part
+
+np.random.seed(37)
+train_percent = 0.1
+
+training_idx = np.random.randint(fish_data.shape[0], size=int(fish_data.shape[0] * train_percent))
+test_idx = np.random.randint(fish_data.shape[0], size=int(fish_data.shape[0] * (1-train_percent)))
+training, test = fish_data[training_idx], fish_data[test_idx]
+
+fish_metalog = pm.metalog(x=training, bounds=[0,40], boundedness='b', term_limit=13, term_lower_bound=2, step_len=.001, penalty='l2', alpha=0.0001, save_data=True)
+
+pm.summary(fish_metalog)
+pm.plot(fish_metalog)
+plt.show()
+
+fish_metalog2 = pm.update(fish_metalog, test, penalty='l2', alpha=0.0001)
+
+pm.summary(fish_metalog2)
+pm.plot(fish_metalog2)
+plt.show()
+

--- a/pymetalog/__init__.py
+++ b/pymetalog/__init__.py
@@ -1,3 +1,3 @@
 from .metalog import metalog
-from .class_method import rmetalog, plot, qmetalog, pmetalog, dmetalog, summary
+from .class_method import rmetalog, plot, qmetalog, pmetalog, dmetalog, summary, update
 name = "pymetalog"

--- a/pymetalog/a_vector.py
+++ b/pymetalog/a_vector.py
@@ -206,6 +206,13 @@ def a_vector_OLS_and_LP(m_dict,
     m_dict['M']['y'] = temp_dict['y']
     m_dict['Validation'] = Validation
 
+    A = np.column_stack((np.repeat(1.,len(A)), A))
+    Est = np.dot(m_dict['Y'], A)
+    ncols = A.shape[1]
+    Z = np.column_stack((np.array(m_dict['dataValues']['z']),np.repeat(m_dict['dataValues']['z'],ncols-1).reshape(len(m_dict['dataValues']['z']),ncols-1)))
+
+    m_dict['square_residual_error'] = ((Z-Est)**2).sum(axis=1)
+
     return m_dict
 
 def a_vector_LP(m_dict, term_limit, term_lower_bound, diff_error = .001, diff_step = 0.001):

--- a/pymetalog/class_method.py
+++ b/pymetalog/class_method.py
@@ -2,7 +2,9 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
+from scipy.stats import t
 from .support import newtons_method_metalog, pdfMetalog_density
+from .metalog import metalog
 
 def summary(m):
   """ Prints information about the fitted metalog m.
@@ -14,6 +16,7 @@ def summary(m):
         - metalog.output_dict['params']['step_len']
         - metalog.output_dict['params']['fit_method']
         - metalog.output_dict['Validation']
+        - metalog.output_dict['params']['nobs']
 
   Args:
       m (:obj:`metalog`): A fitted metalog object.
@@ -29,7 +32,8 @@ def summary(m):
       'Bounds (only used based on boundedness): ', m.output_dict['params']['bounds'], '\n',
       'Step Length for Distribution Summary: ', m.output_dict['params']['step_len'], '\n',
       'Method Use for Fitting: ', m.output_dict['params']['fit_method'], '\n',
-      '\n\n Validation and Fit Method'
+      '\n\n Validation and Fit Method',
+      'Number of Data Points Used: ', m.output_dict['params']['nobs'], '\n'
   )
   print(m.output_dict['Validation'].to_string(index=False))
 
@@ -254,16 +258,16 @@ def qmetalog(m, y, term = 3):
   return(s)
 
 
-def plot(x):
-  """Plots PDF and Quantile panels for each term of fitted metalog x.
+def plot(m):
+  """Plots PDF and Quantile panels for each term of fitted metalog m.
 
   Args:
-      x (:obj:`metalog`): A fitted metalog object.
+      m (:obj:`metalog`): A fitted metalog object.
 
   Returns:
       (:obj:`dict` with keys ['pdf', 'cdf']): PDF and Quantile panel plots.
   """
-  x = x.output_dict
+  x = m.output_dict
   # build plots
   InitalResults = pd.DataFrame(data={
     'term':(np.repeat((str(x['params']['term_lower_bound'])+' Terms'), len(x['M'].iloc[:,0]))),
@@ -358,3 +362,101 @@ def plot(x):
   plt.tight_layout(rect=[0.05, 0.05, 1, 1])
 
   return {'pdf':pdf_fig, 'cdf':cdf_fig}
+
+def update(m, new_data, penalty=None, alpha=0.):
+  """ Updates a previously fitted metalog object with new data.
+
+  Args:
+      m (:obj:`metalog`): The previously fitted metalog object to be updated with `new_data`.
+        - `save_data` parameter must have been set equal to True in original metalog fit.
+
+      new_data (:obj:`list` | `numpy.ndarray` | `pandas.Series`): Input data to update the metalog object with.
+        - must be an array of allowable types: int, float, numpy.int64, numpy.float64
+
+      penalty (:obj:`str`, optional): Used to specify the norm used in the regularization.
+          - must be in set ('l2', None)
+              * 'l2' performs Ridge Regression instead of OLS
+                  - Automatically shrinks a coefficients, leading to "smoother" fits
+          - should be set in conjunction with `alpha` parameter
+          - Default: None
+
+      alpha (:obj:`float`, optional): Regularization term to add to OLS fit.
+          - strictly >= 0.
+          - should be set in conjunction with `penalty` parameter
+          - Default: 0. (no regularization, OLS)
+
+  Returns:
+      (:obj:`metalog`): Input metalog object that has been updated using `new_data`
+
+  Raises:
+    ValueError: 'Input metalog `m.save_data` parameter must be True'
+    TypeError: 'Input x must be an array or pandas Series'
+    TypeError: 'Input x must be an array of allowable types: int, float, numpy.int64, or numpy.float64'
+    IndexError: 'Input x must be of length 3 or greater'
+  """
+
+  if not m.save_data:
+    raise ValueError('Input metalog `m.save_data` parameter must be True')
+  if (type(new_data) != list) and (type(new_data) != np.ndarray) and (type(new_data) != pd.Series):
+    raise TypeError('Input x must be an array or pandas Series')
+  if isinstance(new_data, pd.Series):
+    new_data = new_data.values.copy()
+  if not all([isinstance(x, (int, float, np.int64, np.float64)) for x in new_data]):
+    raise TypeError('Input x must be an array of allowable types: int, float, numpy.int64, or numpy.float64')
+  if np.size(new_data) < 3:
+    raise IndexError('Input x must be of length 3 or greater') 
+
+  old_append_new_data = np.append(m.x, new_data)
+
+  updated_metalog = metalog(old_append_new_data,
+                                bounds = m.output_dict['params']['bounds'],
+                                boundedness = m.output_dict['params']['boundedness'],
+                                term_limit = m.output_dict['params']['term_limit'],
+                                term_lower_bound = m.output_dict['params']['term_lower_bound'],
+                                step_len = m.output_dict['params']['step_len'],
+                                probs = None,
+                                fit_method = m.output_dict['params']['fit_method'],
+                                penalty = penalty,
+                                alpha = alpha,
+                                save_data = True)
+
+  Y = updated_metalog.output_dict['Y'].values
+  gamma = Y.T.dot(Y)
+  updated_metalog.output_dict['params']['bayes']['gamma'] = gamma
+  updated_metalog.output_dict['params']['bayes']['mu'] = updated_metalog.output_dict['A']
+  v = list()
+  for i in range(updated_metalog.output_dict['params']['term_lower_bound'], updated_metalog.output_dict['params']['term_limit'] + 1):
+    v.append(updated_metalog.output_dict['params']['nobs']-i)
+  v = np.array(v)
+  a = v/2
+  updated_metalog.output_dict['params']['bayes']['a'] = a
+  updated_metalog.output_dict['params']['bayes']['v'] = v
+
+  # for now, just using 3 term standard metalog
+  v = v[1]
+  a = a[1]
+  s = np.array([0.1, 0.5, 0.9])
+  Ys = np.repeat(1., 3)
+
+  Ys = np.column_stack([np.repeat(1, 3), np.log(s / (1 - s)), (s - 0.5)*np.log(s / (1 - s))])
+  three_term_metalog_fit_idx = 'a{}'.format(updated_metalog.term_limit - 3)
+  q_bar = np.dot(Ys, updated_metalog.output_dict['A'][three_term_metalog_fit_idx].values[-3:])
+
+  updated_metalog.output_dict['params']['bayes']['q_bar'] = q_bar
+
+  est = (q_bar[2]-q_bar[1])/2 + q_bar[1]
+  s2 = ((q_bar[2] - q_bar[1]) / t.ppf(0.9,np.array(v)))**2
+
+  gamma = gamma[:3,:3]
+
+  # build covariance matrix for students t
+  sig = Ys.dot(np.linalg.solve(gamma, np.eye(len(gamma)))).dot(Ys.T)
+
+  # b = 0.5 * self.output_dict['params']['square_residual_error'][len(self.output_dict['params']['square_residual_error'])]
+  b = (a * s2) / gamma[1,1]
+  updated_metalog.output_dict['params']['bayes']['sig'] = (b/a)*sig
+  updated_metalog.output_dict['params']['bayes']['b'] = b
+
+  return updated_metalog
+
+  

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from scipy.stats import t
 from .support import MLprobs
 from .a_vector import a_vector_OLS_and_LP
 
@@ -24,7 +25,8 @@ class metalog():
     Homepage: http://www.metalogdistributions.com/
 
     Attributes:
-        x (:obj: `numpy.ndarray`): Input array to fit the metalog distribution to.
+        x (:obj: `numpy.ndarray`): Input array being fit with the metalog distribution.
+        nobs (:obj:`int`): Number of data points in x.
         boundedness (:obj: `str`): String type of metalog to fit ('u' | 'sl' | 'su' | 'b').
         bounds (:obj: `list`): List upper and lower limits to filter array with before calculating metalog quantiles/pdfs.
         term_limit (:obj: `int`): Int upper limit of the range of metalog terms to use to fit the data.
@@ -32,8 +34,9 @@ class metalog():
         step_len (:obj: `float`): Float bin width used to estimate the metalog fit.
         probs (:obj: `numpy.ndarray`): Input array of probabilities associated with the data values in `x`.
         fit_method (:obj: `str`): String type of metalog fit method ('any' | 'OLS' | 'LP' | 'MLE').
-        penalty (:obj:`str`, optional): Used to specify the norm used in the regularization.
-        alpha (:obj:`float`, optional): Regularization term to add to OLS fit.
+        penalty (:obj:`str`): Used to specify the norm used in the regularization.
+        alpha (:obj:`float`): Regularization term to add to OLS fit.
+        save_data (:obj:`bool`, optional): T/F to save copy of input data `x` with metalog object.
 
         output_dict (:obj:`dict` with keys ['params', 'dataValues', 'Y', 'A', 'M', 'Validation']).
             - output_dict['params'] (:obj:`dict`):
@@ -43,6 +46,7 @@ class metalog():
                 - output_dict['params']['term_lower_bound'] = `term_lower_bound`
                 - output_dict['params']['step_len'] = `step_len`
                 - output_dict['params']['fit_method'] = `fit_method`
+                - output_dict['params']['square_residual_error'] = Squared residual error (y_i - yhat_i)^2`                
 
             - output_dict['dataValues'] (:obj:`dict`).
                 - output_dict['dataValues']['x']: `x`
@@ -88,7 +92,7 @@ class metalog():
         append_zvector(`bounds`, `boundedness`) -> df_x: (:obj:`pandas.DataFrame` with columns ['x','probs','z'] of type numeric)
         
     """
-    def __init__(self, x, bounds=[0,1], boundedness='u', term_limit=13, term_lower_bound=2, step_len=.01, probs=None, fit_method='any', penalty=None, alpha=0.):
+    def __init__(self, x, bounds=[0,1], boundedness='u', term_limit=13, term_lower_bound=2, step_len=.01, probs=None, fit_method='any', penalty=None, alpha=0., save_data = False):
         """Fits a metalog distribution using the input array `x`.
 
         Args:
@@ -146,6 +150,12 @@ class metalog():
                 - should be set in conjunction with `penalty` parameter
                 - Default: 0. (no regularization, OLS)
 
+            save_data (:obj:`bool`, optional): Saves copy of input data `x` with metalog object.
+                - strictly boolean (True, False)
+                - saves a copy of data used to fit metalog object
+                    * Used for Bayesian updating
+                - Default: False
+
         Raises:
             TypeError: 'Input x must be an array or pandas Series'
             TypeError: 'Input x must be an array of allowable types: int, float, numpy.int64, or numpy.float64'
@@ -175,6 +185,7 @@ class metalog():
             ValueError: 'fit_method can only be values OLS, LP, any, or MLE'
             ValueError: 'penalty can only be values l2 or None'
             ValueError: 'alpha must only be a float >= 0.'
+            ValueError: 'save_data must only be boolean.'
 
         Example:
 
@@ -203,6 +214,8 @@ class metalog():
         self.probs = probs
         self.fit_method = fit_method
         self.penalty = penalty
+        self.nobs = len(x)
+        self.save_data = save_data
 
         if penalty == None:
             alpha = 0.
@@ -258,6 +271,54 @@ class metalog():
             alpha = self.alpha,
             diff_error = .001,
             diff_step = 0.001)
+
+        # Build the Components for Baysiean Updating
+
+        if self.save_data & self.term_lower_bound <= 3:
+            Y = self.output_dict['Y']
+            gamma = np.dot(self.output_dict['Y'].T, self.output_dict['Y'])
+
+            self.output_dict['params']['bayes'] = {'gamma': gamma}
+            self.output_dict['params']['bayes']['mu'] = self.output_dict['A']
+            
+            v = list()
+            for i in range(term_lower_bound,term_limit+1):
+              v.append(self.output_dict['params']['nobs'] - i)
+            v = np.array(v)
+            a = v/2
+
+            self.output_dict['params']['bayes']['a'] = a
+            self.output_dict['params']['bayes']['v'] = v            
+
+            # for now, just using 3 term standard metalog
+            v = v[1]
+            a = a[1]
+            s = np.array([0.1, 0.5, 0.9])
+            Ys = np.repeat(1., 3)
+
+            Ys = np.column_stack([np.repeat(1, 3), np.log(s / (1 - s)), (s - 0.5)*np.log(s / (1 - s))])
+            three_term_metalog_fit_idx = 'a{}'.format(self.term_limit - 3)
+            q_bar = np.dot(Ys, self.output_dict['A'][three_term_metalog_fit_idx].values[-3:])
+
+            self.output_dict['params']['bayes']['q_bar'] = q_bar
+
+            # estimate b using q_90 assessment
+
+            est = (q_bar[2]-q_bar[1])/2 + q_bar[1]
+            s2 = ((q_bar[2] - q_bar[1]) / t.ppf(0.9,np.array(v)))**2
+
+            gamma = gamma[:3,:3]
+
+            # build covariance matrix for students t
+            sig = Ys.dot(np.linalg.solve(gamma, np.eye(len(gamma)))).dot(Ys.T)
+
+            # b = 0.5 * self.output_dict['params']['square_residual_error'][len(self.output_dict['params']['square_residual_error'])]
+            b = (a * s2) / gamma[1,1]
+            self.output_dict['params']['bayes']['sig'] = (b/a)*sig
+            self.output_dict['params']['bayes']['b'] = b
+
+        else:
+            del self.x
 
 
     # input validation...
@@ -423,6 +484,18 @@ class metalog():
             raise ValueError('alpha must only be a float >= 0.')
         self._alpha = a
 
+    @property
+    def save_data(self):
+        """save_data (:obj:`bool`, optional): Saves copy of input data `x` with metalog object."""
+
+        return self._save_data
+
+    @save_data.setter
+    def save_data(self, sd):
+        if not type(sd) is bool:
+            raise ValueError('save_data must only be boolean.')
+        self._save_data = sd
+
     def get_params(self):
         """Sets the `params` key (dict) of `output_dict` object prior to input to `a_vector_OLS_and_LP` method.
             - Uses metalog attributes to set keys
@@ -439,6 +512,8 @@ class metalog():
         params['term_lower_bound'] = self.term_lower_bound
         params['step_len'] = self.step_len
         params['fit_method'] = self.fit_method
+        params['nobs'] = self.nobs
+        params['save_data'] = self.save_data
 
         return params
 


### PR DESCRIPTION
Followed the rmetalog lead and implemented metalog Bayesian updating using the standard 3-term metalog and the Student-t distribution quantile function to perform the update and capture stats about what updated.

Functionally, `pm.update` function takes in a fitted metalog and the new_data to update the metalog distribution. See example below.

For the plots below, I updated PyMetalog_usagetest.py to first split the data into 90/10 and 5/95 sets. I then fit the metalog to each of the data split schemas by first fitting to set on left side of slash, then updating the fitted metalog object with the remainder of the data.

Plots on the left represent resultant metalog after fitting to set on left side of slash, plots on the right represent resultant metalog after updating fit to include all data.

![Picture1](https://user-images.githubusercontent.com/24706343/71324744-6670de00-24a8-11ea-996a-175b33faf3e9.png)

Pretty good fit on 90% of data, including 100% of the data smooths out some of the peaks to a lower density. This used L2 regularization in the update method.

![Picture1](https://user-images.githubusercontent.com/24706343/71324911-9b7e3000-24aa-11ea-8dbb-909511bb2cc9.png)

Pretty bad fit on 5% of data, including 100% of the data converges to expected fit. This used L2 regularization in the update method.

`pm.update` function allows for `l2` regularization to be specified. Tbh I haven't completely wrapped my head around the `metalog.output_dict['params']['bayes']` dict the `update` method returns.