### PR TITLE
Patch 1

### DIFF
--- a/pymetalog/a_vector.py
+++ b/pymetalog/a_vector.py
@@ -212,7 +212,8 @@ def a_vector_OLS_and_LP(m_dict,
     A = np.column_stack((np.repeat(1.,len(A)), A))
     Est = np.dot(m_dict['Y'], A)
     ncols = A.shape[1]
-    Z = np.column_stack((np.array(m_dict['dataValues']['z']),np.repeat(m_dict['dataValues']['z'].values,ncols-1).reshape(len(m_dict['dataValues']['z']),ncols-1)))
+    
+    Z = np.column_stack((np.array(m_dict['dataValues']['z']),np.repeat(np.array(m_dict['dataValues']['z']),ncols-1).reshape(len(m_dict['dataValues']['z']),ncols-1)))
 
     m_dict['square_residual_error'] = ((Z-Est)**2).sum(axis=1)
 

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -483,7 +483,7 @@ class metalog():
             raise KeyError()
         return self.output_dict[arr]
     
-    def cdf(self,value,term=self['params']['term_limit']):
+    def cdf(self,value,term=None):
         """Returns the Cumulative distribution function for the given value
         
         Inputs:
@@ -493,6 +493,9 @@ class metalog():
         Returns:
             cdf: (:float:value of Cumulative distribution function 
         """
+        if not term:
+            term = self['params']['term_limit']
+            
         if term < 2:
             raise ValueError('minimum number of terms is 2')
         

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -494,13 +494,13 @@ class metalog():
             cdf: (:float:value of Cumulative distribution function 
         """
         if not term:
-            term = self['params']['term_limit']
+            term = 2
             
         if term < 2:
             raise ValueError('minimum number of terms is 2')
         
         x = self.output_dict
-          # build plots
+        
         InitalResults = pd.DataFrame(data={
         'term':(np.repeat((str(x['params']['term_lower_bound'])+' Terms'), len(x['M'].iloc[:,0]))),
         'pdfValues':x['M'].iloc[:,0],
@@ -518,5 +518,5 @@ class metalog():
 
         InitalResults = InitalResults.append(pd.DataFrame(data=TempResults), ignore_index=True)
         
-        return InitalResults[InitalResults['term']==InitalResults.term.unique()[term-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[t-2]]['quantileValues']-value))]
+        return InitalResults[InitalResults['term']==InitalResults.term.unique()[term-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[t-2]]['quantileValues']-value))]['cumValue']
 

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -517,7 +517,7 @@ class metalog():
                     'cumValue':x['M']['y']
                   })
 
-        InitalResults = InitalResults.append(pd.DataFrame(data=TempResults), ignore_index=True)
+                InitalResults = InitalResults.append(pd.DataFrame(data=TempResults), ignore_index=True)
         
         if hasattr(value, "__len__"):
             return np.array([InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]]['quantileValues']-v))]['cumValue'] for v in map(float,value)])

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -483,20 +483,20 @@ class metalog():
             raise KeyError()
         return self.output_dict[arr]
     
-    def cdf(self,value,term=None):
+    def cdf(self,value,terms=None):
         """Returns the Cumulative distribution function for the given value
         
         Inputs:
             - 'value': value
-            - 'term': number of metalog terms
+            - 'terms': number of metalog terms, default 2
 
         Returns:
             cdf: (:float:value of Cumulative distribution function 
         """
-        if not term:
-            term = 2
+        if not terms:
+            terms = 2
             
-        if term < 2:
+        if terms < 2:
             raise ValueError('minimum number of terms is 2')
         
         x = self.output_dict
@@ -517,6 +517,6 @@ class metalog():
                   })
 
         InitalResults = InitalResults.append(pd.DataFrame(data=TempResults), ignore_index=True)
-        
-        return InitalResults[InitalResults['term']==InitalResults.term.unique()[term-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[t-2]]['quantileValues']-value))]['cumValue']
+                
+        return InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]]['quantileValues']-value))]['cumValue']
 

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -495,7 +495,8 @@ class metalog():
         """
         if not terms:
             terms = 2
-            
+        
+        terms=int(terms)    
         if terms < 2:
             raise ValueError('minimum number of terms is 2')
         
@@ -517,6 +518,10 @@ class metalog():
                   })
 
         InitalResults = InitalResults.append(pd.DataFrame(data=TempResults), ignore_index=True)
-                
-        return InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]]['quantileValues']-value))]['cumValue']
+        
+        if hasattr(value, "__len__"):
+            return np.array([InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]]['quantileValues']-v))]['cumValue'] for v in map(float,value)])
+        else:
+            value = float(value)
+            return InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[terms-2]]['quantileValues']-value))]['cumValue']
 

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -482,4 +482,38 @@ class metalog():
         if arr not in self.output_dict:
             raise KeyError()
         return self.output_dict[arr]
+    
+    def cdf(self,value,term=self['params']['term_limit']):
+        """Returns the Cumulative distribution function for the given value
+        
+        Inputs:
+            - 'value': value
+            - 'term': number of metalog terms
+
+        Returns:
+            cdf: (:float:value of Cumulative distribution function 
+        """
+        if term < 2:
+            raise ValueError('minimum number of terms is 2')
+        
+        x = self.output_dict
+          # build plots
+        InitalResults = pd.DataFrame(data={
+        'term':(np.repeat((str(x['params']['term_lower_bound'])+' Terms'), len(x['M'].iloc[:,0]))),
+        'pdfValues':x['M'].iloc[:,0],
+        'quantileValues':x['M'].iloc[:,1],
+        'cumValue':x['M']['y']})
+
+        if len(x['M'].columns) > 3:
+            for i in range(2,((len(x['M'].iloc[0,:]) - 1) // 2 + 1)):
+                TempResults = pd.DataFrame(data={
+                    'term':np.repeat((str(x['params']['term_lower_bound'] + (i-1))+' Terms'),len(x['M'].iloc[:,0])),
+                    'pdfValues':x['M'].iloc[:,(i * 2 - 2)],
+                    'quantileValues':x['M'].iloc[:, (i * 2 - 1)],
+                    'cumValue':x['M']['y']
+                  })
+
+        InitalResults = InitalResults.append(pd.DataFrame(data=TempResults), ignore_index=True)
+        
+        return InitalResults[InitalResults['term']==InitalResults.term.unique()[term-2]].iloc[np.argmin(abs(InitalResults[InitalResults['term']==InitalResults.term.unique()[t-2]]['quantileValues']-value))]
 

--- a/pymetalog/metalog.py
+++ b/pymetalog/metalog.py
@@ -491,7 +491,7 @@ class metalog():
             - 'terms': number of metalog terms, default 2
 
         Returns:
-            cdf: (:float:value of Cumulative distribution function 
+            cdf: (:obj:`float`): value of Cumulative distribution function
         """
         if not terms:
             terms = 2


### PR DESCRIPTION
when `pymetalog.metalog()` function is called with an input array `x` longer than 100 (`len(x)>100`), there is the following error on line 215 of `a_vector.py`:
`AttributeError: 'numpy.ndarray' object has no attribute 'values'
`

`m_dict['dataValues']['z']` is a `numpy.array`, not a `pandas.Series`. The following change should fix that.